### PR TITLE
Optimize CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ clean_secrets: &clean_secrets
     name: Cleanup secrets
     command: signing/cleanup.sh
 
-workflow_filter_all: &workflow_filter_all
+filter_all_tags: &filter_all_tags
   filters:
     tags:
       only: /.*/
@@ -159,17 +159,17 @@ workflows:
   build_test_deploy:
     jobs:
       - build_debug:
-          <<: *workflow_filter_all
+          <<: *filter_all_tags
       - test_instrumented:
           requires:
             - build_debug
-          <<: *workflow_filter_all
+          <<: *filter_all_tags
       - check:
           requires:
             - build_debug
-          <<: *workflow_filter_all
+          <<: *filter_all_tags
       - build_release:
           requires:
             - test_instrumented
             - check
-          <<: *workflow_filter_all
+          <<: *filter_all_tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
         - <<: *restore_cache
         - run:
             name: Check app and dependencies
-            command: ./gradlew check dependencyUpdates
+            command: ./gradlew dependencyUpdates lintRelease spotlessCheck testReleaseUnitTest
         - store_artifacts:
             path: app/build/reports
             destination: reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,16 +160,19 @@ workflows:
     jobs:
       - build_debug:
           <<: *filter_all_tags
-      - test_instrumented:
-          requires:
-            - build_debug
-          <<: *filter_all_tags
       - check:
           requires:
             - build_debug
           <<: *filter_all_tags
       - build_release:
           requires:
-            - test_instrumented
             - check
           <<: *filter_all_tags
+      - test_instrumented:
+          requires:
+            - build_debug
+          filters:
+            branches:
+              only: /release-.*/
+            tags:
+              only: /.*/


### PR DESCRIPTION
- Avoid running unit tests on CI twice
- Run tests on Firebase Test Lab only for release branches