### PR TITLE
Build test APK on CI only when running instrumented tests 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,8 @@ jobs:
           name: Download Dependencies
           command: ./gradlew dependencies
       - run:
-          name: Assemble and Test APKs
-          command: ./gradlew assembleDebug app:assembleDebugAndroidTest
+          name: Assemble debug APKs
+          command: ./gradlew assembleDebug
       - <<: *clean_secrets
       - <<: *save_cache
       - store_artifacts:
@@ -140,14 +140,18 @@ jobs:
     steps:
       - checkout
       - <<: *attach_workspace
+      - <<: *gen_cache_key
+      - <<: *restore_cache
       - <<: *decrypt_secrets
+      - run:
+          name: Build test APKs
+          command: ./gradlew assembleDebugAndroidTest
       - run:
           name: Setup Google Cloud auth
           command: ftl-tests/setup.sh
       - run:
           name: Run tests on Firebase Test Lab
           command: ftl-tests/run-tests.sh $CIRCLE_BUILD_NUM firebase_test_results
-          when: always
       - <<: *clean_secrets
       - store_artifacts:
           path: firebase_test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,13 @@ filter_all_tags: &filter_all_tags
     tags:
       only: /.*/
 
+filter_release_branch: &filter_release_branch
+  filters:
+    branches:
+      only: /release-.*/
+    tags:
+      only: /.*/
+
 jobs:
   build_debug:
     <<: *config_android
@@ -135,17 +142,27 @@ jobs:
           destination: reports
       - <<: *persist_workspace
 
-  test_instrumented:
-    <<: *config_gcloud
+  build_test:
+    <<: *config_android
     steps:
       - checkout
       - <<: *attach_workspace
       - <<: *gen_cache_key
       - <<: *restore_cache
-      - <<: *decrypt_secrets
       - run:
           name: Build test APKs
           command: ./gradlew assembleDebugAndroidTest
+      - store_artifacts:
+          path: app/build/outputs
+          destination: outputs
+      - <<: *persist_workspace
+
+  test_instrumented:
+    <<: *config_gcloud
+    steps:
+      - checkout
+      - <<: *attach_workspace
+      - <<: *decrypt_secrets
       - run:
           name: Setup Google Cloud auth
           command: ftl-tests/setup.sh
@@ -168,15 +185,15 @@ workflows:
           requires:
             - build_debug
           <<: *filter_all_tags
+      - build_test:
+          requires:
+            - build_debug
+          <<: *filter_release_branch
+      - test_instrumented:
+          requires:
+            - build_test
+          <<: *filter_release_branch
       - build_release:
           requires:
             - check
           <<: *filter_all_tags
-      - test_instrumented:
-          requires:
-            - build_debug
-          filters:
-            branches:
-              only: /release-.*/
-            tags:
-              only: /.*/

--- a/ftl-tests/run-tests.sh
+++ b/ftl-tests/run-tests.sh
@@ -9,7 +9,7 @@ test_apk() {
 	    --type instrumentation \
 	    --app $2 \
 	    --test $3 \
-	    --device model=Nexus6P,version=27,locale=en_US,orientation=portrait \
+	    --device model=walleye,version=28,locale=en_US,orientation=portrait \
 	    --timeout 20m \
 	    --results-dir=${RESULTS_DIR} \
 	    --environment-variables coverage=true,coverageFile=/sdcard/tmp/code-coverage/connected/coverage.ec \


### PR DESCRIPTION
This way `build_debug` job runs around ~10s faster.
At the same time we spend additional minute or so building test APK, but we do this only for release branches, so the overall speed gain should be significant.