### PR TITLE
Don't run CI builds on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,11 +61,6 @@ clean_secrets: &clean_secrets
     name: Cleanup secrets
     command: signing/cleanup.sh
 
-filter_all_tags: &filter_all_tags
-  filters:
-    tags:
-      only: /.*/
-
 filter_release_branch: &filter_release_branch
   filters:
     branches:
@@ -220,11 +215,17 @@ workflows:
   build_test_publish:
     jobs:
       - build_debug:
-          <<: *filter_all_tags
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /master/
       - check:
           requires:
             - build_debug
-          <<: *filter_all_tags
+          filters:
+            tags:
+              only: /.*/
       - build_test:
           requires:
             - build_debug


### PR DESCRIPTION
We don't need to run master branch through CI because:

1. We commit changes directly to master branch only when they pertain to documentation, and this has no impact on builds.
2. We introduce code changes to master branch only by merging with release branches. The latter are always run through CI.
3. We also don't need master branch for release builds because we run those for 'v.' tags.