### PR TITLE
Remove scope annotation from Dagger Module @Binds method

### DIFF
--- a/app/src/main/java/com/qwertyfinger/androidsimpleboilerplate/inject/AppModuleBinds.kt
+++ b/app/src/main/java/com/qwertyfinger/androidsimpleboilerplate/inject/AppModuleBinds.kt
@@ -36,7 +36,6 @@ import com.qwertyfinger.androidsimpleboilerplate.util.Logger
 import com.qwertyfinger.androidsimpleboilerplate.util.TimberLogger
 import dagger.Binds
 import dagger.Module
-import dagger.Reusable
 import dagger.multibindings.IntoSet
 
 @Module
@@ -44,7 +43,6 @@ abstract class AppModuleBinds {
   @Binds
   abstract fun provideContext(application: Application): Context
 
-  @Reusable
   @Binds
   abstract fun provideLogger(bind: TimberLogger): Logger
 


### PR DESCRIPTION
> When binding an implementation to an interface, there shouldn’t be any scoping annotation.
> Statefulness is an implementation detail – only implementations know if they need to ensure centralized access to mutable state.

– from [Keeping the Daggers Sharp](https://medium.com/square-corner-blog/keeping-the-daggers-sharp-%EF%B8%8F-230b3191c3f#b498) by Py