### PR TITLE
Apply Dagger compiler optimizations only for non-CI builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,6 @@
 import buildsrc.Libraries
 import buildsrc.Versions
 
-ext {
-  ci = System.getenv('CI') == 'true'
-}
-
 buildscript {
   repositories {
     google()
@@ -56,6 +52,10 @@ plugins {
   id 'com.diffplug.gradle.spotless' version '3.20.0'
   id 'com.github.ben-manes.versions' version '0.21.0'
   id 'com.github.triplet.play' version '2.1.1'
+}
+
+ext {
+  ci = System.getenv('CI') == 'true'
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,10 @@
 import buildsrc.Libraries
 import buildsrc.Versions
 
+ext {
+  ci = System.getenv('CI') == 'true'
+}
+
 buildscript {
   repositories {
     google()
@@ -70,10 +74,14 @@ allprojects {
         javacOptions {
           option('-Xmaxerrs', 500)
         }
-        // Disable generated code formatting and enable incremental builds for Dagger
+        // Disable generated code formatting and enable incremental builds for Dagger.
+        // kapt should start supporting incremental annotation processors in upcoming 1.3.30 release.
+        // See https://youtrack.jetbrains.com/issue/KT-23880
         arguments {
-          arg('dagger.formatGeneratedSource', 'disabled')
-          arg('dagger.gradle.incremental', 'enabled')
+          if (!ci) {
+            arg('dagger.formatGeneratedSource', 'disabled')
+            arg('dagger.gradle.incremental', 'enabled')
+          }
         }
       }
     }


### PR DESCRIPTION
- Enable formatting of Dagger's generated code for CI builds to avoid unreadable stack traces.
- Disable Dagger's incremental annotation processing (which [should become supported by kapt](https://youtrack.jetbrains.com/issue/KT-23880) in upcoming 1.3.30 release) when on CI.